### PR TITLE
Use rp_id as rp_name if rp_name is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Django-fido provides basic components for FIDO 2 authentication - model to store
        ]
 
 4. If you wish, set string variable `DJANGO_FIDO_RP_NAME`.
-   This is only required if you use `python-fido >= 0.15`.
 
 ## Changes ##
 See [changelog](https://github.com/CZ-NIC/django-fido/blob/master/CHANGELOG.md).

--- a/django_fido/tests/test_views.py
+++ b/django_fido/tests/test_views.py
@@ -45,9 +45,10 @@ class TestFido2RegistrationRequestView(TestCase):
     def _get_fido2_request(self, challenge, credentials):
         credential_params = [{'alg': -7, 'type': 'public-key'}, {'alg': -8, 'type': 'public-key'},
                              {'alg': -37, 'type': 'public-key'}, {'alg': -257, 'type': 'public-key'}]
-        rp_data = {'id': HOSTNAME}
-        if fido2.__version__ < '0.8':
-            rp_data['name'] = HOSTNAME
+        rp_data = {
+            'id': HOSTNAME,
+            'name': HOSTNAME,
+        }
         fido2_request = {'publicKey': {
             'rp': rp_data,
             'user': {'displayName': USER_FULL_NAME, 'id': USERNAME, 'name': USERNAME},

--- a/django_fido/views.py
+++ b/django_fido/views.py
@@ -41,6 +41,9 @@ class Fido2ViewMixin(object):
     """
     Mixin with common methods for all FIDO 2 views.
 
+    @cvar rp_name: Name of the relying party.
+        If None, the value of setting ``DJANGO_FIDO_RP_NAME`` is used instead.
+        If None, the RP ID is used instead.
     @cvar attestation: Attestation conveyance preference,
                        see https://www.w3.org/TR/webauthn/#enumdef-attestationconveyancepreference
     @cvar session_key: Session key where the FIDO 2 state is stored.
@@ -49,10 +52,11 @@ class Fido2ViewMixin(object):
     attestation = AttestationConveyancePreference.NONE
     session_key = FIDO2_REQUEST_SESSION_KEY
 
-    @property
-    def rp_name(self) -> Optional[str]:
-        """Return relying party name set in django settings."""
-        return SETTINGS.rp_name
+    rp_name = None  # type: Optional[str]
+
+    def get_rp_name(self) -> Optional[str]:
+        """Return relying party name."""
+        return self.rp_name or SETTINGS.rp_name or self.get_rp_id()
 
     def get_rp_id(self) -> str:
         """Return RP id - only a hostname for web services."""
@@ -62,7 +66,7 @@ class Fido2ViewMixin(object):
     @property
     def server(self) -> Fido2Server:
         """Return FIDO 2 server instance."""
-        rp = PublicKeyCredentialRpEntity(self.get_rp_id(), self.rp_name)
+        rp = PublicKeyCredentialRpEntity(self.get_rp_id(), self.get_rp_name())
         return Fido2Server(rp, attestation=self.attestation)
 
     @abstractmethod


### PR DESCRIPTION
Closes #40.