### PR TITLE
Fix default value of auth backends setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog #
 
+## Unreleased ##
+ * Fix issue caused by default value of `DJANGO_FIDO_AUTHENTICATION_BACKENDS`. It is now empty list.
+
 ## 0.17 ##
  * **BREAKING** Replace `Fido2ModelAuthenticationBackend` with more general `Fido2GeneralAuthenticationBackend`.
 

--- a/django_fido/settings.py
+++ b/django_fido/settings.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from appsettings import AppSettings, BooleanSetting, CallablePathSetting, NestedListSetting, StringSetting
-from django.contrib.auth.backends import ModelBackend
 
 
 class DjangoFidoSettings(AppSettings):
@@ -10,7 +9,7 @@ class DjangoFidoSettings(AppSettings):
 
     authentication_backends = NestedListSetting(
         inner_setting=CallablePathSetting(),
-        default=(ModelBackend,),
+        default=(),
     )
     rp_name = StringSetting(default=None)
     two_step_auth = BooleanSetting(default=True)


### PR DESCRIPTION
Temporary fix until https://github.com/Genida/django-appsettings/pull/61
is resolved.