### PR TITLE
changing function force_text to force_str

### DIFF
--- a/django_fido/models.py
+++ b/django_fido/models.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.db import models
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from fido2.ctap2 import AttestationObject, AttestedCredentialData
@@ -57,7 +57,7 @@ class TransportsValidator(object):
 
     def __call__(self, value):
         """Validate the input."""
-        for chunk in force_text(value).split(','):
+        for chunk in force_str(value).split(','):
             if chunk not in self.choices:
                 raise ValidationError(self.message, code=self.code, params={'value': chunk})
 

--- a/django_fido/views.py
+++ b/django_fido/views.py
@@ -63,7 +63,7 @@ if AttestationVerifier is not None:
             """Return empty CA lookup to disable trust path verification."""
             return []
 
-
+# a
 @unique
 class Fido2ServerError(str, Enum):
     """FIDO 2 server error types."""

--- a/django_fido/views.py
+++ b/django_fido/views.py
@@ -63,7 +63,7 @@ if AttestationVerifier is not None:
             """Return empty CA lookup to disable trust path verification."""
             return []
 
-# a
+
 @unique
 class Fido2ServerError(str, Enum):
     """FIDO 2 server error types."""

--- a/django_fido/views.py
+++ b/django_fido/views.py
@@ -18,7 +18,7 @@ from django.forms import Form
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, View
 from fido2.attestation import Attestation, UnsupportedType
@@ -157,8 +157,8 @@ class BaseFido2RequestView(Fido2ViewMixin, View, metaclass=ABCMeta):
         except ValueError as error:
             return JsonResponse({
                 'error_code': getattr(error, 'error_code', Fido2ServerError.DEFAULT),
-                'message': force_text(error),
-                'error': force_text(error),  # error key is deprecated and will be removed in the future
+                'message': force_str(error),
+                'error': force_str(error),  # error key is deprecated and will be removed in the future
             }, status=BAD_REQUEST)
 
         # Encode challenge into base64 encoding


### PR DESCRIPTION
On Django 4.0 the function force_text was removed. Here, I have changed the function force_text to force_str, in order to get this lib working with Django 4.0