### PR TITLE
Add support for fido2 1.1.0

### DIFF
--- a/django_fido/tests/test_admin.py
+++ b/django_fido/tests/test_admin.py
@@ -5,6 +5,7 @@ from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
+from fido2.utils import websafe_encode
 
 import django_fido.admin.authenticator
 from django_fido.models import Authenticator
@@ -45,11 +46,10 @@ class TestFido2RegistrationRequestAdminView(TestCase):
         self.client.force_login(self.superuser)
 
         response = self.client.get(self.url, data={'user': str(self.user.pk)})
-
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['publicKey']['user'], {
             'displayName': 'Kryten 2X4B-523P',
-            'id': 'kryten',
+            'id': websafe_encode(b'kryten'),
             'name': 'kryten',
         })
 

--- a/django_fido/tests/test_views.py
+++ b/django_fido/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user, get_user_model
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
-from fido2.utils import websafe_decode
+from fido2.utils import websafe_decode, websafe_encode
 
 from django_fido.constants import AUTHENTICATION_USER_SESSION_KEY, FIDO2_REQUEST_SESSION_KEY
 from django_fido.models import Authenticator
@@ -50,7 +50,7 @@ class TestFido2RegistrationRequestView(TestCase):
         }
         fido2_request = {'publicKey': {
             'rp': rp_data,
-            'user': {'displayName': USER_FULL_NAME, 'id': USERNAME, 'name': USERNAME},
+            'user': {'displayName': USER_FULL_NAME, 'id': websafe_encode(bytes(USERNAME, encoding="utf-8")), 'name': USERNAME},
             'challenge': base64.b64encode(challenge).decode('utf-8'),
             'pubKeyCredParams': credential_params,
             'attestation': 'none',

--- a/django_fido/views.py
+++ b/django_fido/views.py
@@ -160,8 +160,7 @@ class BaseFido2RequestView(Fido2ViewMixin, View, metaclass=ABCMeta):
 
         # Store the state into session
         self.request.session[self.session_key] = state
-
-        return JsonResponse(request_data, encoder=Fido2Encoder)
+        return JsonResponse(request_data, encoder=Fido2Encoder, safe=False)
 
 
 class Fido2RegistrationRequestView(LoginRequiredMixin, BaseFido2RequestView):
@@ -171,7 +170,7 @@ class Fido2RegistrationRequestView(LoginRequiredMixin, BaseFido2RequestView):
         """Return user which is subject of the request."""
         return self.request.user
 
-    def get_user_id(self, user: AbstractBaseUser) -> str:
+    def get_user_id(self, user: AbstractBaseUser) -> bytes:
         """Return a unique, persistent identifier of a user.
 
         Default implementation return user's username, but it is only secure if the username can't be reused.
@@ -182,8 +181,8 @@ class Fido2RegistrationRequestView(LoginRequiredMixin, BaseFido2RequestView):
         If resident_key is True, we need to return an uuid string that does not disclose user identity
         """
         if SETTINGS.resident_key:
-            return uuid.uuid4().hex
-        return user.username
+            return uuid.uuid4().bytes
+        return bytes(user.username, encoding="utf-8")
 
     def get_user_data(self, user: AbstractBaseUser) -> Dict[str, str]:
         """Convert user instance to user data for registration."""

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     django31: django == 3.1.*
     django32: django == 3.2.*
     django40: django == 4.0.*
-    fido10: fido2==1.0.*
+    fido11: fido2==1.1.*
 commands =
     coverage run --source=django_fido --branch -m django test {posargs:django_fido}
 


### PR DESCRIPTION
Modified `get_user_id` to return bytes according to `PublicKeyCredentialUserEntity` specification.

There are also changes in related JSON serialization but it appears that custom encoder for handling bytes is still necessary.